### PR TITLE
Add pg_log_userqueries.log_regexp custom configuration directive to log…

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 pg_log_userqueries is a PostgreSQL module that logs each query executed by a
-superuser. It records each query in the standard log file.
+user or/and on a database. It records each query in the standard log file.
+Default is to log superusers queries executed on all database. It is also
+possible to filter the queries to be logged through a regular expression.
 
 To install pg_log_userqueries, you should untar the pg_log_userqueries tarball
 anywhere you want.
@@ -35,8 +37,8 @@ You can specify exactly what you want to log:
 If none of the following four variables is set, all queries issued by superusers will be logged
 in all databases, and only those.
 
-If you set any of log_db, log_user, or log_addr, superuser queries won't be systematically logged,
-and you'll have to set log_superusers to on to reactivate it.
+If you set any of log_db, log_user, log_addr or log_regexp superuser queries won't be
+systematically logged, and you'll have to set log_superusers to on to reactivate it.
 
 * pg_log_userqueries.log_superusers: to turn on/off logging of all superusers (off by default)
 * pg_log_userqueries.log_db: to give a pipe (|) separated list of database to log.
@@ -45,10 +47,19 @@ and you'll have to set log_superusers to on to reactivate it.
 
 You can use advanced regular expression in that list. For example:
 
-* pg_log_userqueries.log_user="^postgres$|^admin_.*|.*_adm$"
+* pg_log_userqueries.log_user="postgres|admin_.*|.*_adm"
 
 will match if the exact username is 'postgres', or if it begins with 'admin_' or
 ends with '_adm'.
+
+You can also use pg_log_userqueries to log queries matching a particular regular
+expression using a the 'pg_log_userqueries.log_regexp' dedicated configuration directive:
+
+* pg_log_userqueries.log_regexp: to give a regular expression to log all queries matching this regexp.
+
+For example to only log calls related to prepared transaction statements you can set the following:
+
+    pg_log_userqueries.log_regexp="^(PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)"
 
 By default, pg_log_userqueries will write queries to PostgreSQL log destination.
 A superuser can change this behavior with the pg_log_userqueries.log_destination

--- a/README
+++ b/README
@@ -37,7 +37,7 @@ You can specify exactly what you want to log:
 If none of the following four variables is set, all queries issued by superusers will be logged
 in all databases, and only those.
 
-If you set any of log_db, log_user, log_addr or log_regexp superuser queries won't be
+If you set any of log_db, log_user, log_addr or log_query superuser queries won't be
 systematically logged, and you'll have to set log_superusers to on to reactivate it.
 
 * pg_log_userqueries.log_superusers: to turn on/off logging of all superusers (off by default)
@@ -53,13 +53,13 @@ will match if the exact username is 'postgres', or if it begins with 'admin_' or
 ends with '_adm'.
 
 You can also use pg_log_userqueries to log queries matching a particular regular
-expression using a the 'pg_log_userqueries.log_regexp' dedicated configuration directive:
+expression using a the 'pg_log_userqueries.log_query' dedicated configuration directive:
 
-* pg_log_userqueries.log_regexp: to give a regular expression to log all queries matching this regexp.
+* pg_log_userqueries.log_query: to give a regular expression to log all queries matching this regexp.
 
 For example to only log calls related to prepared transaction statements you can set the following:
 
-    pg_log_userqueries.log_regexp="^(PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)"
+    pg_log_userqueries.log_query="^(PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)"
 
 By default, pg_log_userqueries will write queries to PostgreSQL log destination.
 A superuser can change this behavior with the pg_log_userqueries.log_destination

--- a/pg_log_userqueries.c
+++ b/pg_log_userqueries.c
@@ -77,7 +77,7 @@ static char *  log_label = NULL;
 static char *  log_user = NULL;
 static char *  log_db = NULL;
 static char *  log_addr = NULL;
-static char *  log_regexp = NULL;
+static char *  log_query = NULL;
 static bool    log_superusers = false;
 static int     regex_flags = REG_NOSUB;
 static regex_t usr_regexv;
@@ -283,10 +283,10 @@ _PG_init(void)
 #endif
 				NULL,
 				NULL);
-   DefineCustomStringVariable( "pg_log_userqueries.log_regexp",
+   DefineCustomStringVariable( "pg_log_userqueries.log_query",
 				"Log statement according to the given regular expression.",
 				NULL,
-				&log_regexp,
+				&log_query,
 				NULL,
 				PGC_POSTMASTER,
 				0,
@@ -335,11 +335,11 @@ _PG_init(void)
 		pfree(tmp);
 	}
 	/* Compile rexgep to log statement */
-	if (log_regexp != NULL)
+	if (log_query != NULL)
 	{
-		if (regcomp(&query_regexv, log_regexp, regex_flags) != 0)
+		if (regcomp(&query_regexv, log_query, regex_flags) != 0)
 		{
-			ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE), errmsg("pg_log_userqueries: invalid statement regexp pattern %s", log_regexp)));
+			ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE), errmsg("pg_log_userqueries: invalid statement regexp pattern %s", log_query)));
 		}
 	}
 
@@ -499,7 +499,7 @@ static bool pgluq_check_log()
 	 * log only superuser queries
 	 */
 
-	if ((log_db == NULL) && (log_user == NULL) && (log_addr == NULL) && (log_regexp == NULL) && superuser())
+	if ((log_db == NULL) && (log_user == NULL) && (log_addr == NULL) && (log_query == NULL) && superuser())
 		return true;
 
 	/*
@@ -551,7 +551,7 @@ pgluq_log(const char *query)
 	Assert(query != NULL);
 
 	/* when log regexp statement is set do not log the query if it doesn't match the regexp */
-	if ((log_regexp != NULL) && (regexec(&query_regexv, query, 0, 0, 0) != 0))
+	if ((log_query != NULL) && (regexec(&query_regexv, query, 0, 0, 0) != 0))
 		return;
 
 	tmp_log_query = log_prefix(query);


### PR DESCRIPTION
queries matching a particular regular expression. For example to only log calls related to prepared transaction statements you can set the following:
```
    pg_log_userqueries.log_regexp="^(PREPARE TRANSACTION|COMMIT PREPARED|ROLLBACK PREPARED)$"
```
- Fix description of the project to reflect all main features.
- Fix log_user regexp.